### PR TITLE
make emails case insensitive

### DIFF
--- a/src/server/collections/user/mutations/login.ts
+++ b/src/server/collections/user/mutations/login.ts
@@ -9,7 +9,7 @@ async function loginResolver(
   req: Express.Request,
 ): Promise<CurrentUserPayload> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (req as any).body.username = username;
+  (req as any).body.username = username.toLowerCase();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (req as any).body.password = password;
   return new Promise((resolve, reject) => {

--- a/src/server/collections/user/mutations/register.ts
+++ b/src/server/collections/user/mutations/register.ts
@@ -4,15 +4,17 @@ import analytics from 'src/server/analytics';
 import type { CurrentUserPayload } from 'src/server/collections/user/UserGraphQLTypes';
 import { CurrentUserGraphQLType } from 'src/server/collections/user/UserGraphQLTypes';
 import { UserModel } from 'src/server/collections/user/UserModel';
+import matchStringCaseInsensitive from 'src/shared/utils/regexp/matchStringCaseInsensitive';
 
 async function registerResolver(
   _: unknown,
-  { username, password }: { username: string; password: string },
+  { username: username_, password }: { username: string; password: string },
   req: Express.Request,
 ): Promise<CurrentUserPayload> {
+  const username = username_.toLowerCase();
   const allowlistEntry = await mongoose.connection.db
     .collection('email-allowlist')
-    .findOne({ email: username });
+    .findOne({ email: matchStringCaseInsensitive(username) });
   if (allowlistEntry == null) {
     throw new Error(
       "To protect the privacy of our users' data, you cannot create an account without first being added to the list of allowed users. Please email new.user@dandelion.supplies if you'd like to be added!",

--- a/src/shared/utils/regexp/escapeRegExp.ts
+++ b/src/shared/utils/regexp/escapeRegExp.ts
@@ -1,0 +1,5 @@
+// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+
+export default function escapeRegExp(val: string): string {
+  return val.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}

--- a/src/shared/utils/regexp/matchStringCaseInsensitive.ts
+++ b/src/shared/utils/regexp/matchStringCaseInsensitive.ts
@@ -1,0 +1,6 @@
+import escapeRegExp from 'src/shared/utils/regexp/escapeRegExp';
+
+export default function matchStringCaseInsensitive(val: string): RegExp {
+  const escaped = escapeRegExp(val);
+  return new RegExp(escaped, 'i');
+}


### PR DESCRIPTION
Fixes #170

# Testing:

Created a new allowlist entry:

<img width="359" alt="Screen Shot 2022-02-15 at 8 02 55 AM" src="https://user-images.githubusercontent.com/4309735/154101314-cd096078-cba4-4f6c-bb56-5351194009d2.png">

Registered with a different capitalization of that email address:

<img width="341" alt="Screen Shot 2022-02-15 at 8 03 26 AM" src="https://user-images.githubusercontent.com/4309735/154101473-92f3f463-ba33-4449-8b35-282347b5bc3c.png">

<img width="340" alt="Screen Shot 2022-02-15 at 8 03 33 AM" src="https://user-images.githubusercontent.com/4309735/154101488-b16648c3-a727-488f-9d1b-647caafe1310.png">

Logged in with a different capitalization of that email address:
<img width="342" alt="Screen Shot 2022-02-15 at 8 03 51 AM" src="https://user-images.githubusercontent.com/4309735/154101534-f427c379-f244-416f-9cbf-cf57f99a6c22.png">

<img width="335" alt="Screen Shot 2022-02-15 at 8 03 57 AM" src="https://user-images.githubusercontent.com/4309735/154101555-82e526ce-7646-4795-866b-7c19672569c8.png">

Verified that it's ok to treat email addresses as case insensitive:

<img width="625" alt="Screen Shot 2022-02-15 at 8 05 51 AM" src="https://user-images.githubusercontent.com/4309735/154101615-02400dd9-fcd6-41ab-86fa-98737db58607.png">

