### PR TITLE
notif settings back button goes to detail screen

### DIFF
--- a/src/client/aid_request/explorer/RequestExplorerTabStackContainer.tsx
+++ b/src/client/aid_request/explorer/RequestExplorerTabStackContainer.tsx
@@ -21,6 +21,8 @@ export default function RequestExplorerTabStackContainer(): JSX.Element {
   const [aidRequest, setAidRequest] = React.useState<
     AidRequestDetailsQuery_aidRequest | undefined
   >(undefined);
+  const [notifSettingsAidRequestID, setNotifSettingsAidRequestID] =
+    React.useState<string | undefined>(undefined);
   const AidRequestDetailScreenComponent = React.useCallback((props) => {
     return (
       <AidRequestDetailScreen
@@ -35,6 +37,23 @@ export default function RequestExplorerTabStackContainer(): JSX.Element {
       />
     );
   }, []);
+  const AidRequestNotificationSettingsScreenComponent = React.useCallback(
+    (props) => {
+      return (
+        <AidRequestNotificationSettingsScreen
+          {...props}
+          setNotifSettingsAidRequestID={(
+            newNotifSettingsAidRequestID: string,
+          ): void => {
+            if (notifSettingsAidRequestID !== newNotifSettingsAidRequestID) {
+              setNotifSettingsAidRequestID(newNotifSettingsAidRequestID);
+            }
+          }}
+        />
+      );
+    },
+    [],
+  );
   return (
     <StackNavigatorInsideTabNavigator>
       <Stack.Navigator>
@@ -61,12 +80,24 @@ export default function RequestExplorerTabStackContainer(): JSX.Element {
           })}
         />
         <Stack.Screen
-          component={AidRequestNotificationSettingsScreen}
+          component={AidRequestNotificationSettingsScreenComponent}
           name="AidRequestNotificationSettings"
           options={() => ({
             header: ({ options }) => (
               <Header>
-                <Appbar.BackAction onPress={goBack} />
+                <Appbar.BackAction
+                  onPress={() => {
+                    const navigation =
+                      RequestExplorerNavigationStore.getValue();
+                    navigation?.canGoBack()
+                      ? navigation?.goBack()
+                      : notifSettingsAidRequestID == null
+                      ? navigation?.replace('RequestExplorer')
+                      : navigation?.replace('AidRequestDetail', {
+                          id: notifSettingsAidRequestID,
+                        });
+                  }}
+                />
                 <Appbar.Content title={options.title} />
               </Header>
             ),

--- a/src/client/aid_request/notification_settings/AidRequestNotificationSettingsScreen.tsx
+++ b/src/client/aid_request/notification_settings/AidRequestNotificationSettingsScreen.tsx
@@ -27,7 +27,9 @@ type Item = {
   key: string;
 };
 
-type Props = RequestExplorerStackScreenProps<'AidRequestDetail'>;
+type Props = RequestExplorerStackScreenProps<'AidRequestDetail'> & {
+  setNotifSettingsAidRequestID: (aidRequestID: string) => void;
+};
 
 export default function AidRequestNotificationSettingsScreenWrapper(
   props: Props,
@@ -40,8 +42,14 @@ export default function AidRequestNotificationSettingsScreenWrapper(
   );
 }
 
-function AidRequestNotificationSettingsScreen({ route }: Props): JSX.Element {
+function AidRequestNotificationSettingsScreen({
+  route,
+  setNotifSettingsAidRequestID,
+}: Props): JSX.Element {
   const { id: aidRequestID } = route.params;
+  React.useEffect(() => {
+    setNotifSettingsAidRequestID(aidRequestID);
+  }, [aidRequestID]);
   const { data, loading, error, refetch } = useQuery<
     AidRequestNotificationSettingsQuery,
     AidRequestNotificationSettingsQueryVariables


### PR DESCRIPTION
when you open the notification settings link from the email, the back button should take you back to the request detail screen